### PR TITLE
chore: use `DataPayload` as input/output format for Execute()

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,8 @@ require (
 	github.com/docker/docker v24.0.2+incompatible
 	github.com/ghodss/yaml v1.0.0
 	github.com/gofrs/uuid v4.4.0+incompatible
-	github.com/instill-ai/connector v0.0.0-20230607085408-06a038e17b8e
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230523000406-299e9451af13
+	github.com/instill-ai/connector v0.0.0-20230615093707-edf8710c4ddb
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230615091607-d5e75c7bc0dd
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.0
 	go.uber.org/zap v1.24.0
 	google.golang.org/protobuf v1.30.0

--- a/go.sum
+++ b/go.sum
@@ -35,12 +35,10 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.15.2 h1:gDLXvp5S9izjldquuoAhDzccbsk
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.15.2/go.mod h1:7pdNwVWBBHGiCxa9lAszqCJMbfTISJ7oMftp8+UGV08=
 github.com/iancoleman/strcase v0.2.0 h1:05I4QRnGpI0m37iZQRuskXh+w77mr6Z41lwQzuHLwW0=
 github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
-github.com/instill-ai/connector v0.0.0-20230607055515-44d11e5e909e h1:dDfwBTvKb0hBy5g7MK9Gj6BRoAyS4k6f8szFO+hLP/M=
-github.com/instill-ai/connector v0.0.0-20230607055515-44d11e5e909e/go.mod h1:JQSmkMUh4dWHjL+BXwCbQvJfIOEr5D57iiGasr4xTaI=
-github.com/instill-ai/connector v0.0.0-20230607085408-06a038e17b8e h1:s2gsgcINuuedPF/iQKzsMlaGQMO2I5dGj98XuIs+3uk=
-github.com/instill-ai/connector v0.0.0-20230607085408-06a038e17b8e/go.mod h1:JQSmkMUh4dWHjL+BXwCbQvJfIOEr5D57iiGasr4xTaI=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230523000406-299e9451af13 h1:qC0Xe0zCpmgq02vClxL4OS1ZLjDmFUn/KuJOtJxINmI=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230523000406-299e9451af13/go.mod h1:7/Jj3ATVozPwB0WmKRM612o/k5UJF8K9oRCNKYH8iy0=
+github.com/instill-ai/connector v0.0.0-20230615093707-edf8710c4ddb h1:2COcd1xqha168hbcFJW7RXoqop/T52Z2NYuToRBeoXI=
+github.com/instill-ai/connector v0.0.0-20230615093707-edf8710c4ddb/go.mod h1:njRy7QkM8b5tnDihZdpZy8tfN86Sz8a26VEMPM8sRFQ=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230615091607-d5e75c7bc0dd h1:Tu2JRlXKZpC5AfoZO23xf8AkDZxvxqr/Ve+Yw1GtKS8=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230615091607-d5e75c7bc0dd/go.mod h1:7/Jj3ATVozPwB0WmKRM612o/k5UJF8K9oRCNKYH8iy0=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
 github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a h1:bbPeKD0xmW/Y25WS6cokEszi5g+S0QxI/d45PkRi7Nk=
 github.com/jackc/pgx/v5 v5.3.0 h1:/NQi8KHMpKWHInxXesC8yD4DhkXPrVhmnwYkjp9AmBA=

--- a/pkg/airbyte/airbyte.go
+++ b/pkg/airbyte/airbyte.go
@@ -62,16 +62,6 @@ type ConfiguredAirbyteStream struct {
 	PrimaryKey          []string       `json:"primary_key"`
 }
 
-// WriteDestinationConnectorParam stores the parameters for WriteDestinationConnector service per model
-type WriteDestinationConnectorParam struct {
-	SyncMode           string
-	DstSyncMode        string
-	Pipeline           string
-	Recipe             *pipelinePB.Recipe
-	DataMappingIndices []string
-	ModelOutputs       []*pipelinePB.ModelOutput
-}
-
 // TaskOutputAirbyteCatalog stores the pre-defined task AirbyteCatalog
 var TaskOutputAirbyteCatalog AirbyteCatalog
 

--- a/pkg/instill/main.go
+++ b/pkg/instill/main.go
@@ -46,7 +46,10 @@ func Init(logger *zap.Logger) base.IConnector {
 			BaseConnector: base.BaseConnector{Logger: logger},
 		}
 		for idx := range connDefs {
-			connector.AddConnectorDefinition(uuid.FromStringOrNil(connDefs[idx].GetUid()), connDefs[idx].GetId(), connDefs[idx])
+			err := connector.AddConnectorDefinition(uuid.FromStringOrNil(connDefs[idx].GetUid()), connDefs[idx].GetId(), connDefs[idx])
+			if err != nil {
+				logger.Warn(err.Error())
+			}
 		}
 	})
 	return connector
@@ -59,7 +62,7 @@ func (c *Connector) CreateConnection(defUid uuid.UUID, config *structpb.Struct, 
 	}, nil
 }
 
-func (con *Connection) Execute(input interface{}) (interface{}, error) {
+func (con *Connection) Execute(input []*connectorPB.DataPayload) ([]*connectorPB.DataPayload, error) {
 	return input, nil
 }
 

--- a/pkg/main.go
+++ b/pkg/main.go
@@ -21,7 +21,6 @@ type Connector struct {
 	base.BaseConnector
 	airbyteConnector base.IConnector
 	instillConnector base.IConnector
-	numbersConnector base.IConnector
 }
 
 type ConnectorOptions struct {
@@ -50,14 +49,20 @@ func Init(logger *zap.Logger, options ConnectorOptions) base.IConnector {
 			if err != nil {
 				logger.Error(err.Error())
 			}
-			connector.AddConnectorDefinition(uid, def.GetId(), def)
+			err = connector.AddConnectorDefinition(uid, def.GetId(), def)
+			if err != nil {
+				logger.Warn(err.Error())
+			}
 		}
 		for _, uid := range instillConnector.ListConnectorDefinitionUids() {
 			def, err := instillConnector.GetConnectorDefinitionByUid(uid)
 			if err != nil {
 				logger.Error(err.Error())
 			}
-			connector.AddConnectorDefinition(uid, def.GetId(), def)
+			err = connector.AddConnectorDefinition(uid, def.GetId(), def)
+			if err != nil {
+				logger.Warn(err.Error())
+			}
 		}
 		// for _, uid := range numbersConnector.ListConnectorDefinitionUids() {
 		// 	def, err := numbersConnector.GetConnectorDefinitionByUid(uid)

--- a/pkg/numbers/main.go
+++ b/pkg/numbers/main.go
@@ -48,7 +48,10 @@ func Init(logger *zap.Logger, options ConnectorOptions) base.IConnector {
 			BaseConnector: base.BaseConnector{Logger: logger},
 		}
 		for idx := range connDefs {
-			connector.AddConnectorDefinition(uuid.FromStringOrNil(connDefs[idx].GetUid()), connDefs[idx].GetId(), connDefs[idx])
+			err := connector.AddConnectorDefinition(uuid.FromStringOrNil(connDefs[idx].GetUid()), connDefs[idx].GetId(), connDefs[idx])
+			if err != nil {
+				logger.Warn(err.Error())
+			}
 		}
 	})
 	return connector
@@ -61,7 +64,7 @@ func (c *Connector) CreateConnection(defUid uuid.UUID, config *structpb.Struct, 
 	}, nil
 }
 
-func (con *Connection) Execute(input interface{}) (interface{}, error) {
+func (con *Connection) Execute(input []*connectorPB.DataPayload) ([]*connectorPB.DataPayload, error) {
 	return input, nil
 }
 


### PR DESCRIPTION
Because

- we defined a unified format for interchange data in pipeline

This commit

- use `DataPayload` as input/output format for `Execute()`
