### PR TITLE
chore: update connector pkg and loader

### DIFF
--- a/example/sample/main.go
+++ b/example/sample/main.go
@@ -5,7 +5,6 @@ import (
 
 	connectorDestination "github.com/instill-ai/connector-destination/pkg"
 	connectorDestinationAirbyte "github.com/instill-ai/connector-destination/pkg/airbyte"
-	connectorPB "github.com/instill-ai/protogen-go/vdp/connector/v1alpha"
 	"go.uber.org/zap"
 )
 
@@ -25,7 +24,7 @@ func main() {
 
 	// For apis: Get connector definitsion apis
 	for _, v := range connector.ListConnectorDefinitions() {
-		fmt.Println(v.(*connectorPB.DestinationConnectorDefinition).GetId())
+		fmt.Println(v)
 	}
 
 	// in connector-backend:

--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,8 @@ require (
 	github.com/docker/docker v24.0.2+incompatible
 	github.com/ghodss/yaml v1.0.0
 	github.com/gofrs/uuid v4.4.0+incompatible
-	github.com/instill-ai/connector v0.0.0-20230619103836-51161aed8f55
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230619103359-cde5e4f5e898
+	github.com/instill-ai/connector v0.0.0-20230626100237-5ecbb3c4c57a
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230626081036-adbc33794c42
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.0
 	go.uber.org/zap v1.24.0
 	google.golang.org/protobuf v1.30.0

--- a/go.sum
+++ b/go.sum
@@ -29,10 +29,10 @@ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.15.2 h1:gDLXvp5S9izjldquuoAhDzccbskOL6tDC5jMSyx3zxE=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.15.2/go.mod h1:7pdNwVWBBHGiCxa9lAszqCJMbfTISJ7oMftp8+UGV08=
-github.com/instill-ai/connector v0.0.0-20230619103836-51161aed8f55 h1:L366FMxbeIRCqgE6qcEEPTfToqscXZEuOrOFRArjPJM=
-github.com/instill-ai/connector v0.0.0-20230619103836-51161aed8f55/go.mod h1:T2JBePI9hYuoQGd6lBCek6TCTPcUkBx3pNpeokywWeU=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230619103359-cde5e4f5e898 h1:9ValC5UmT+UpWQDYrEsTkxkXgYTcQhRAZzg4EJiQoz4=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230619103359-cde5e4f5e898/go.mod h1:7/Jj3ATVozPwB0WmKRM612o/k5UJF8K9oRCNKYH8iy0=
+github.com/instill-ai/connector v0.0.0-20230626100237-5ecbb3c4c57a h1:CpMdixXmtZ7sv6eMbTnXRbKOPwXEMI38TODua+Kpf2o=
+github.com/instill-ai/connector v0.0.0-20230626100237-5ecbb3c4c57a/go.mod h1:m+xoiWEQElLcxGuYdU9wb+DVD6rQ1g72xHYyOW0m+Ek=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230626081036-adbc33794c42 h1:mmRaW6Tz/j2jqoKCGvo3V1HK4aCxs3/RDOaDjrWMvAo=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230626081036-adbc33794c42/go.mod h1:qsq5ecnA1xi2rLnVQFo/9xksA7I7wQu8c7rqM5xbIrQ=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=

--- a/pkg/instill/main.go
+++ b/pkg/instill/main.go
@@ -36,10 +36,12 @@ type Connection struct {
 
 func Init(logger *zap.Logger) base.IConnector {
 	once.Do(func() {
-		connDefs := []*connectorPB.DestinationConnectorDefinition{}
-
 		loader := configLoader.InitJSONSchema(logger)
-		loader.Load(venderName, destinationJson, &connDefs)
+		connDefs, err := loader.Load(venderName, connectorPB.ConnectorType_CONNECTOR_TYPE_DESTINATION, destinationJson)
+
+		if err != nil {
+			panic(err)
+		}
 
 		connector = &Connector{
 			BaseConnector: base.BaseConnector{Logger: logger},
@@ -61,8 +63,8 @@ func (c *Connector) CreateConnection(defUid uuid.UUID, config *structpb.Struct, 
 	}, nil
 }
 
-func (con *Connection) Execute(input []*connectorPB.DataPayload) ([]*connectorPB.DataPayload, error) {
-	return input, nil
+func (con *Connection) Execute(inputs []*connectorPB.DataPayload) ([]*connectorPB.DataPayload, error) {
+	return inputs, nil
 }
 
 func (con *Connection) Test() (connectorPB.Connector_State, error) {


### PR DESCRIPTION
Because

- the configLoader has been updated in connector pkg

This commit

- update connector pkg and use new `configLoader`
