### PR TITLE
chore: merge `destination-http` and `destination-grpc` to `response`

### DIFF
--- a/pkg/instill/config/seed/definitions.json
+++ b/pkg/instill/config/seed/definitions.json
@@ -1,48 +1,25 @@
 [
   {
     "custom": false,
-    "documentationUrl": "https://www.instill.tech/docs/destination-connectors/http",
-    "icon": "grpc.svg",
+    "documentationUrl": "https://www.instill.tech/docs/destination-connectors/response",
+    "icon": "response.svg",
     "iconUrl": "",
-    "id": "destination-http",
+    "id": "response",
     "public": true,
     "spec": {
-      "documentationUrl": "https://www.instill.tech/docs/destination-connectors/http",
+      "documentationUrl": "https://www.instill.tech/docs/destination-connectors/response",
       "connectionSpecification": {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "title": "http Destination Connector Spec",
+        "title": "Response Connector Spec",
         "type": "object",
         "required": [],
         "additionalProperties": false,
         "properties": {}
       }
     },
-    "title": "http",
+    "title": "Response",
     "tombstone": false,
     "uid": "909c3278-f7d1-461c-9352-87741bef11d3",
-    "vendorAttributes": {}
-  },
-  {
-    "custom": false,
-    "documentationUrl": "https://www.instill.tech/docs/destination-connectors/grpc",
-    "icon": "grpc.svg",
-    "iconUrl": "",
-    "id": "destination-grpc",
-    "public": true,
-    "spec": {
-      "documentationUrl": "https://www.instill.tech/docs/destination-connectors/grpc",
-      "connectionSpecification": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
-        "title": "gRPC Destination Connector Spec",
-        "type": "object",
-        "required": [],
-        "additionalProperties": false,
-        "properties": {}
-      }
-    },
-    "title": "gRPC",
-    "tombstone": false,
-    "uid": "c0e4a82c-9620-4a72-abd1-18586f2acccd",
     "vendorAttributes": {}
   }
 ]


### PR DESCRIPTION
Because

- it is not user-friendly to have separated `http` and `grpc` connector

This commit

- merge `destination-http` and `destination-grpc` to `response`
